### PR TITLE
Support the '*' keyword in a step name

### DIFF
--- a/lib/tests/utils.spec.ts
+++ b/lib/tests/utils.spec.ts
@@ -62,4 +62,19 @@ describe( 'utils', () => {
             expect( new Utils().containsSteps( steps, language ) ).toEqual( true );
         } );
     } );
+
+    describe( 'keywordStartsWith', () => {
+        it( 'should return undefined if the first word is not a keyword', () => {
+            const language = 'en';
+
+            expect( new Utils().keywordStartsWith( 'Milk is not a reserved keyword', language ) ).toBeUndefined();
+        } );
+
+        it( 'should return the first word if it is a keyword', () => {
+            const language = 'en';
+
+            // * is a valid keyword in Gherkin
+            expect( new Utils().keywordStartsWith( '* I have milk', language ) ).toEqual( '*' );
+        } );
+    } );
 } );

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -16,8 +16,7 @@ export default class Utils {
         const dialect = dialects[language];
         return ( [] as string[] )
             .concat( dialect.given, dialect.when, dialect.then, dialect.and )
-            .map( keyword => keyword.replace( /\s*$/, '' ) )
-            .filter( keyword => keyword !== '*' );
+            .map( keyword => keyword.replace( /\s*$/, '' ) );
     }
 
     /**
@@ -62,7 +61,8 @@ export default class Utils {
      */
     public keywordStartsWith ( title: string, language: string ): string | undefined {
         const stepKeywords = [].concat( this.getStepKeywords( language ), ['After', 'Before'] );
-        const regex = new RegExp( `^(${stepKeywords.join( '|' )})\\s` );
+        const escapedStepKeywords = stepKeywords.map( ( keyword: string ) => keyword.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' ) );
+        const regex = new RegExp( `^(${escapedStepKeywords.join( '|' )})\\s` );
         return ( regex.exec( title ) || [] ).pop() as string;
     }
 }


### PR DESCRIPTION
There is a possibility to use the '*' keyword in the Gherkin language instead of one of the other common keywords (like Given or And). This can be handy when listing things, as for example
```
Scenario: All done
  Given I am out shopping
  * I have eggs
  * I have milk
  * I have butter
  When I check my list
  Then I don't need anything
```
([See Gherkin syntax](https://cucumber.io/docs/gherkin/reference/))

Unfortunately this is not supported for some reason by the json reporter.

Is there a reason why this keyword is explicitly filtered out from the list of keywords (utils.ts:20)?
```
public getStepKeywords ( language: string ): string[] {
        const dialect = dialects[language];
        return ( [] as string[] )
            .concat( dialect.given, dialect.when, dialect.then, dialect.and )
            .map( keyword => keyword.replace( /\s*$/, '' ) )
            .filter( keyword => keyword !== '*' ); // <---
    }
```

As of now, steps defined like this have their names parsed incorrectly and this results in meaningless step names, like in this report:

<img width="527" alt="Screenshot 2022-02-09 at 14 05 43" src="https://user-images.githubusercontent.com/15244556/153211582-6b52897e-f15a-4f2c-8298-cbdb41ec8937.png">

Whereas with this fix, the names are displayed correctly:

<img width="529" alt="Screenshot 2022-02-09 at 14 04 02" src="https://user-images.githubusercontent.com/15244556/153211705-f7a1f16f-4c91-45f0-9aeb-44dcc2015f77.png">

This fix removes the filtering out of the '*' keywords and also escapes the strings so that they don't break the regular expressions. The escape regex originally comes from [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#escaping).

Note: Technically there will be duplicate '*'s in the keywords array (`stepKeywords`), if that is an issue the duplicates can be removed.