### PR TITLE
add backwards compatibility option to create only one report file per spec on retry 

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ The language in which the Gherkin scenarios are written (defaults to English). T
 
 Hook details will not be part of generation if this property sets to `true`.
 
+### `reportFilePerRetry`
+- **Type:** `boolean`
+- **Mandatory:** No
+- **Default:** `true`
+
+When a spec if retried the report will be appended to the existing report file from the previous tries if this property is set to `false`.
+
 **Example**:
 `['cucumberjs-json', { jsonFolder: '.tmp/new/', language: 'en', disableHooks:true}]`
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Hook details will not be part of generation if this property sets to `true`.
 - **Mandatory:** No
 - **Default:** `true`
 
-When a spec if retried the report will be appended to the existing report file from the previous tries if this property is set to `false`.
+When a spec is retried the report will be appended to the existing report file from the previous tries if this property is set to `false`.
 
 **Example**:
 `['cucumberjs-json', { jsonFolder: '.tmp/new/', language: 'en', disableHooks:true}]`

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -9,3 +9,4 @@ export const PENDING = 'pending';
 export const TEXT_PLAIN = 'text/plain';
 export const DEFAULT_JSON_FOLDER = '.tmp/json/';
 export const DEFAULT_LANGUAGE = 'en';
+export const DEFAULT_REPORT_FILE_PER_RETRY = true;

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -75,7 +75,7 @@ export class Metadata {
         if ( currentCapabilities?.platformVersion ) {
             return currentCapabilities.platformVersion;
         }
-            return `Version ${NOT_KNOWN}`;
+        return `Version ${NOT_KNOWN}`;
     }
 
     /**

--- a/lib/reporter.ts
+++ b/lib/reporter.ts
@@ -3,6 +3,7 @@ import {
     BEFORE,
     DEFAULT_JSON_FOLDER,
     DEFAULT_LANGUAGE,
+    DEFAULT_REPORT_FILE_PER_RETRY,
     FEATURE,
     PASSED,
     //   PENDING,
@@ -38,6 +39,10 @@ export class CucumberJsJsonReporter extends WDIOReporter {
         if ( !this.options.language ) {
             this.options.language = DEFAULT_LANGUAGE;
             log.info( `The 'language' was not set, it has been set to the default '${DEFAULT_LANGUAGE}'` );
+        }
+        if ( this.options.reportFilePerRetry === undefined ) {
+            this.options.reportFilePerRetry = DEFAULT_REPORT_FILE_PER_RETRY;
+            log.info( `The 'reportFilePerRetry' was not set, it has been set to the default '${DEFAULT_REPORT_FILE_PER_RETRY.toString()}'` );
         }
 
         this.instanceMetadata = null;
@@ -207,8 +212,9 @@ export class CucumberJsJsonReporter extends WDIOReporter {
      */
     public onRunnerEnd (): void {
         const uniqueId = String( Date.now() + Math.random() ).replace( '.','' );
+        const filename = this.options.reportFilePerRetry ? `${this.report.feature.id}_${uniqueId}.json` : `${this.report.feature.id}.json`;
         const jsonFolder = resolve( process.cwd(), this.options.jsonFolder );
-        const jsonFile = resolve( jsonFolder, `${this.report.feature.id}_${uniqueId}.json` );
+        const jsonFile = resolve( jsonFolder, filename );
         const json = [this.report.feature];
         // Check if there is an existing file, if so concat the data, else add the new
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument

--- a/lib/tests/__snapshots__/reporter.spec.ts.snap
+++ b/lib/tests/__snapshots__/reporter.spec.ts.snap
@@ -200,6 +200,7 @@ Object {
   "jsonFolder": ".tmp/json/",
   "language": "en",
   "logFile": ".tmp/logFile.json",
+  "reportFilePerRetry": true,
 }
 `;
 
@@ -208,6 +209,7 @@ Object {
   "jsonFolder": ".tmp/json-folder/",
   "language": "en",
   "logFile": ".tmp/logFile.json",
+  "reportFilePerRetry": true,
 }
 `;
 

--- a/lib/tests/reporter.spec.ts
+++ b/lib/tests/reporter.spec.ts
@@ -13,7 +13,7 @@ import {
     TEST_SCENARIO_STATS
 } from './__mocks__/mocks';
 import { HookStatsExtended, RunnerStatsExtended, SuiteStatsExtended, TestStatsExtended } from '../types/wdio';
-import { readJsonSync, readdirSync, removeSync } from 'fs-extra';
+import { copySync, readJsonSync, readdirSync, removeSync } from 'fs-extra';
 import { Metadata } from '../metadata';
 import { Step } from '../models';
 import WdioCucumberJsJsonReporter from '../reporter';
@@ -255,7 +255,7 @@ describe( 'reporter', () => {
             // Clean up
             removeSync( jsonFolder );
         } );
-        it( 'should create unique Json file and should not add in existing Json file onRunnerEnd', () => {
+        it( 'should by default create a unique Json file and should not add in existing Json file onRunnerEnd', () => {
 
             const jsonFolder = './.tmp/ut-folder';
 
@@ -277,6 +277,28 @@ describe( 'reporter', () => {
                     .toEqual( 1 );
 
             }
+            // Clean up
+            removeSync( jsonFolder );
+        } );
+        it( 'should be able to add json to an existing json output when reportFilePerRetry option is set to false', () => {
+            const jsonFolder = './.tmp/ut-folder';
+            const jsonFile = `${jsonFolder}/this-feature.json`;
+
+            copySync( 'lib/tests/__mocks__/mock.json', jsonFile );
+
+            tmpReporter.report.feature = { id: 'this-feature' };
+            tmpReporter.options.jsonFolder = jsonFolder;
+            tmpReporter.options.reportFilePerRetry = false;
+
+            expect( ( readJsonSync( jsonFile ) as any[] ).length ).toEqual( 1 );
+
+            tmpReporter.onRunnerEnd();
+
+            const files = readdirSync( jsonFolder );
+
+            expect( files.length ).toEqual( 1 );
+            expect( ( readJsonSync( jsonFile ) as any[] ).length ).toEqual( 2 );
+
             // Clean up
             removeSync( jsonFolder );
         } );


### PR DESCRIPTION
With [this PR](https://github.com/webdriverio-community/wdio-cucumberjs-json-reporter/pull/84) our reporting infrastructure broke for retried tests, we would like to add back the option to have just one report file per spec