### PR TITLE
fix(doc): updated readme.md file with correct WDIO installation page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install wdio-cucumberjs-json-reporter --save-dev
 
 so it will automatically be added to your `package.json`
 
-Instructions on how to install `WebdriverIO` can be found [here](http://webdriver.io/guide/getstarted/install.html).
+Instructions on how to install `WebdriverIO` can be found [here](https://webdriver.io/docs/gettingstarted).
 
 ## Configuration
 Configure the output directory and the language in your wdio.conf.js file:


### PR DESCRIPTION
updated readme.md file with correct WDIO installation page URL. that is https://webdriver.io/docs/gettingstarted.

<img width="992" alt="Screen Shot 2022-12-16 at 2 14 27 PM" src="https://user-images.githubusercontent.com/8421048/208172254-98566c24-9d7a-442e-9862-02ec8d6bfac9.png">
