### PR TITLE
Bump lewagon/wait-on-check-action from 1.2.0 to 1.3.2

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -27,7 +27,7 @@ jobs:
         # Don't merge updates to GitHub Actions versions automatically.
         # (Some repos may wish to limit by version range (major/minor/patch), or scope (dep vs dev-dep), too.)
         if: contains(steps.metadata.outputs.package-ecosystem, 'npm')
-        uses: lewagon/wait-on-check-action@v1.2.0
+        uses: lewagon/wait-on-check-action@v1.3.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The udpate uses Ruby >= 3 which fixes the error in **update.yml**:

```
   ERROR:  Error installing bundler:
  	The last version of bundler (~> 2) to support your Ruby & RubyGems was 2.4.22. Try installing it with `gem install bundler -v 2.4.22`
  	bundler requires Ruby version >= 3.0.0. The current ruby version is 2.7.4.191.
  Took  13.01 seconds
```

For example, https://github.com/webdriverio-community/wdio-cucumberjs-json-reporter/actions/runs/7958241254/job/21722655336?pr=452#step:3:32.
